### PR TITLE
[Add] DiagnosePage UI 구현 및 공통 컴포넌트 확장

### DIFF
--- a/frontend/src/components/common/EmptyState.jsx
+++ b/frontend/src/components/common/EmptyState.jsx
@@ -1,0 +1,27 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+const EmptyState = ({
+    title = "검색 결과가 없습니다.",
+    message = "다른 검색어를 사용해 보세요.",
+    action = null,
+}) => {
+    return (
+        <div className="min-h-[400px] flex items-center justify-center">
+            <div className="text-center">
+                <h3 className="text-xl font-semibold text-gray-800 mb-2">{title}</h3>
+                <p className="text-gray-600 mb-6 max-w-sm max-auto">{message}</p>
+                {action && <div className="mt-4">{action}</div>}
+            </div>
+        </div>
+    );
+};
+
+EmptyState.propTypes = {
+    title: PropTypes.string,
+    message: PropTypes.string,
+    action: PropTypes.node,
+    className: PropTypes.string
+};
+
+export default EmptyState;

--- a/frontend/src/components/common/LoadingSpinner.jsx
+++ b/frontend/src/components/common/LoadingSpinner.jsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const LoadingSpinner = ({
+    message = "로딩 중입니다...",
+    size = "medium",
+    color = "blue"
+}) => {
+    const sizeClasses = {
+        small: 'w-8 h-8',
+        medium: 'w-16 h-16',
+        large: 'w-32 h-32'
+    };
+
+    const colorClasses = {
+        blue: 'border-blue-600',
+        gray: 'border-gray-600',
+        red: 'border-red-600',
+        green: 'border-green-600',
+        purple: 'border-purple-600'
+    };
+
+    return (
+        <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+            <div className="text-center">
+                <div
+                    className={`animate-spin rounded-full border-b-2 mx-auto ${sizeClasses[size]} ${colorClasses[color]}`}
+                    role='status'
+                    aria-label='Loading...'
+                />
+                <span className="sr-only">로딩 중</span>
+            </div>
+            <p className="mt-4 text-gray-600">{message}</p>
+        </div>
+    );
+};
+
+LoadingSpinner.propTypes = {
+    message: PropTypes.string,
+    size: PropTypes.oneOf(['small', 'medium', 'large']),
+    color: PropTypes.oneOf(['blue', 'gray', 'red', 'green', 'purple'])
+};
+
+export default LoadingSpinner;

--- a/frontend/src/components/common/ScoreCards.jsx
+++ b/frontend/src/components/common/ScoreCards.jsx
@@ -113,6 +113,17 @@ const MY_ACTIVITY_CARDS_CONFIG = [
     }
 ];
 
+const getActiveBarColor = (color) => {
+    const colorMap = {
+        purple: 'bg-purple-600',
+        green: 'bg-green-600',
+        red: 'bg-red-600',
+        blue: 'bg-blue-600',
+        orange: 'bg-orange-600'
+    };
+    return colorMap[color] || 'bg-gray-600';
+};
+
 
 const ScoreCards = ({
     scores,
@@ -143,9 +154,12 @@ const ScoreCards = ({
     }
 
     // grid class 동적 설정
-    const gridCols = cardsConfig.length === 3 ? `grid-cols-1 md:grid-cols-${cardsConfig.length}` : 'grid-cols-1 md:grid-cols-2 lg:grid-cols-4';
+    const gridCols = cardsConfig.length === 3 
+        ? `grid-cols-3 lg:grid-cols-${cardsConfig.length}` 
+        : 'grid-cols-4 md:grid-cols-4 lg:grid-cols-4';
+    
     return (
-        <div className={`grid ${gridCols} gap-6`}>
+        <div className={`grid ${gridCols} gap-2 sm:gap-4 md:gap-6`}>
             {cardsConfig.map((card) => {
                 const IconComponent = card.icon;
                 const isActive = activeTab === card.id;
@@ -156,20 +170,20 @@ const ScoreCards = ({
                         key={card.id}
                         onClick={() => onTabChange(card.id)}
                         className={`${card.bgColor} ${isActive ? card.activeBorderColor : card.borderColor} 
-              border-2 rounded-lg p-6 text-center relative overflow-hidden cursor-pointer 
+              border-2 rounded-lg p-2 sm:p-4 md:p-6 text-center relative overflow-hidden cursor-pointer 
               hover:shadow-md transition-all duration-200 ${isActive ? 'shadow-lg' : ''}`}
                     >
-                        <div className="absolute top-3 right-3">
-                            <IconComponent className={`w-5 h-5 ${card.iconColor}`} />
+                        <div className="absolute top-1 right-1 sm:top-2 sm:right-2 md:top-3 md:right-3">
+                            <IconComponent className={`w-3 h-3 sm:w-4 sm:h-4 md:w-5 md:h-5 ${card.iconColor}`} />
                         </div>
-                        <h3 className={`${card.textColor} text-sm font-medium mb-2`}>
+                        <h3 className={`${card.textColor} text-xs sm:text-sm font-medium mb-1 sm:mb-2`}>
                             {card.title}
                         </h3>
-                        <div className={`${card.textColor} text-3xl font-bold`}>
+                        <div className={`${card.textColor} text-lg sm:text-2xl md:text-3xl font-bold`}>
                             {score}/100
                         </div>
                         {isActive && (
-                            <div className="absolute bottom-0 left-0 right-0 h-1 bg-gradient-to-r from-blue-500 to-purple-500"></div>
+                            <div className={`absolute bottom-0 left-0 right-0 h-1 ${getActiveBarColor(card.color)}`}></div>
                         )}
                     </div>
                 );

--- a/frontend/src/components/common/ScoreCards.jsx
+++ b/frontend/src/components/common/ScoreCards.jsx
@@ -1,0 +1,210 @@
+// 프로젝트 진단, 나의 활동 공통 사용 점수 표시 컴포넌트
+import React from 'react';
+import PropTypes from 'prop-types';
+import {
+    CheckCircleIcon,
+    ShieldCheckIcon,
+    ExclamationTriangleIcon,
+    ChartBarIcon,
+    StarIcon
+} from '@heroicons/react/24/solid';
+
+// 기본 카드 구성 - DiagnosePage에서 사용
+const DEFAULT_CARDS_CONFIG = [
+    {
+        id: 'overview',
+        title: '종합 점수',
+        scoreKey: 'ovrall',
+        color: 'purple',
+        icon: CheckCircleIcon,
+        bgColor: 'bg-purple-50',
+        borderColor: 'border-purple-200',
+        activeBorderColor: 'border-purple-500',
+        textColor: 'text-purple-700',
+        iconColor: 'text-purple-600',
+    },
+    {
+        id: 'health',
+        title: '건강 점수',
+        scoreKey: 'health',
+        color: 'green',
+        icon: ShieldCheckIcon,
+        bgColor: 'bg-green-50',
+        borderColor: 'border-green-200',
+        activeBorderColor: 'border-green-500',
+        textColor: 'text-green-700',
+        iconColor: 'text-green-600',
+    },
+    {
+        id: 'security',
+        title: '보안 점수',
+        scoreKey: 'security',
+        color: 'red',
+        icon: ExclamationTriangleIcon,
+        bgColor: 'bg-red-50',
+        borderColor: 'border-red-200',
+        activeBorderColor: 'border-red-500',
+        textColor: 'text-red-700',
+        iconColor: 'text-red-600',
+    },
+];
+
+// MyActivityPage에서 사용
+const MY_ACTIVITY_CARDS_CONFIG = [
+    {
+        id: 'pr_merged',
+        title: '최근 1개월 PR',
+        subtitle: 'PR merged 수',
+        scoreKey: 'prMerged',
+        color: 'blue',
+        icon: ChartBarIcon,
+        bgColor: 'bg-blue-50',
+        borderColor: 'border-blue-200',
+        activeBorderColor: 'border-blue-500',
+        textColor: 'text-blue-700',
+        iconColor: 'text-blue-600',
+        graphQLQuery: 'pullRequests { merged }',
+        dataType: '코드 기여'
+    },
+    {
+        id: 'issues_created',
+        title: '최근 1개월 Issue',
+        subtitle: 'Issue 작성 수',
+        scoreKey: 'issuesCreated',
+        color: 'orange',
+        icon: ExclamationTriangleIcon,
+        bgColor: 'bg-orange-50',
+        borderColor: 'border-orange-200',
+        activeBorderColor: 'border-orange-500',
+        textColor: 'text-orange-700',
+        iconColor: 'text-orange-600',
+        graphQLQuery: 'issues { createdAt }',
+        dataType: '문제 발견'
+    },
+    {
+        id: 'reviews_count',
+        title: '최근 1개월 Review',
+        subtitle: 'Review 수',
+        scoreKey: 'reviewsCount',
+        color: 'green',
+        icon: ShieldCheckIcon,
+        bgColor: 'bg-green-50',
+        borderColor: 'border-green-200',
+        activeBorderColor: 'border-green-500',
+        textColor: 'text-green-700',
+        iconColor: 'text-green-600',
+        graphQLQuery: 'contributionsCollection { pullRequestReviewContributions }',
+        dataType: '협업 리뷰'
+    },
+    {
+        id: 'repositories_contributed',
+        title: '최근 1개월 Commit',
+        subtitle: '기여 repository 수',
+        scoreKey: 'repositoriesContributed',
+        color: 'purple',
+        icon: StarIcon,
+        bgColor: 'bg-purple-50',
+        borderColor: 'border-purple-200',
+        activeBorderColor: 'border-purple-500',
+        textColor: 'text-purple-700',
+        iconColor: 'text-purple-600',
+        graphQLQuery: '각 기여에서 repo nameWithOwner distinct count',
+        dataType: 'OSS 참여 폭'
+    }
+];
+
+
+const ScoreCards = ({
+    scores,
+    activeTab,
+    onTabChange,
+    variant = 'diagnose', // 'diagnose' or 'myActivity
+    customCards = null
+}) => {
+
+    // 기본 점수 설정
+    const defaultScores = {
+        ovrall: scores.ovrall || 0,
+        health: scores.health || 0,
+        security: scores.security || 0,
+        prMerged: scores.prMerged || 0,
+        issuesCreated: scores.issuesCreated || 0,
+        reviewsCount: scores.reviewsCount || 0,
+        repositoriesContributed: scores.repositoriesContributed || 0
+    };
+
+
+    // 선택된 카드 구성
+    let cardsConfig;
+    if (customCards) {
+        cardsConfig = customCards;
+    } else {
+        cardsConfig = variant === 'myActivity' ? MY_ACTIVITY_CARDS_CONFIG : DEFAULT_CARDS_CONFIG;
+    }
+
+    // grid class 동적 설정
+    const gridCols = cardsConfig.length === 3 ? `grid-cols-1 md:grid-cols-${cardsConfig.length}` : 'grid-cols-1 md:grid-cols-2 lg:grid-cols-4';
+    return (
+        <div className={`grid ${gridCols} gap-6`}>
+            {cardsConfig.map((card) => {
+                const IconComponent = card.icon;
+                const isActive = activeTab === card.id;
+                const score = defaultScores[card.scoreKey] || 0;
+
+                return (
+                    <div
+                        key={card.id}
+                        onClick={() => onTabChange(card.id)}
+                        className={`${card.bgColor} ${isActive ? card.activeBorderColor : card.borderColor} 
+              border-2 rounded-lg p-6 text-center relative overflow-hidden cursor-pointer 
+              hover:shadow-md transition-all duration-200 ${isActive ? 'shadow-lg' : ''}`}
+                    >
+                        <div className="absolute top-3 right-3">
+                            <IconComponent className={`w-5 h-5 ${card.iconColor}`} />
+                        </div>
+                        <h3 className={`${card.textColor} text-sm font-medium mb-2`}>
+                            {card.title}
+                        </h3>
+                        <div className={`${card.textColor} text-3xl font-bold`}>
+                            {score}/100
+                        </div>
+                        {isActive && (
+                            <div className="absolute bottom-0 left-0 right-0 h-1 bg-gradient-to-r from-blue-500 to-purple-500"></div>
+                        )}
+                    </div>
+                );
+            })}
+        </div>
+    );
+};
+
+ScoreCards.propTypes = {
+    scores: PropTypes.shape({
+        ovrall: PropTypes.number,
+        health: PropTypes.number,
+        security: PropTypes.number,
+        prMerged: PropTypes.number,
+        issuesCreated: PropTypes.number,
+        reviewsCount: PropTypes.number,
+        repositoriesContributed: PropTypes.number
+    }).isRequired,
+    activeTab: PropTypes.string.isRequired,
+    onTabChange: PropTypes.func.isRequired,
+    variant: PropTypes.oneOf(['diagnose', 'myActivity']),
+    customCards: PropTypes.arrayOf(PropTypes.shape({
+        id: PropTypes.string.isRequired,
+        title: PropTypes.string.isRequired,
+        scoreKey: PropTypes.string.isRequired,
+        color: PropTypes.string,
+        icon: PropTypes.elementType.isRequired,
+        bgColor: PropTypes.string,
+        borderColor: PropTypes.string,
+        activeBorderColor: PropTypes.string,
+        textColor: PropTypes.string,
+        iconColor: PropTypes.string,
+        graphQLQuery: PropTypes.string,
+        dataType: PropTypes.string
+    }))
+};
+
+export default ScoreCards;

--- a/frontend/src/components/common/index.js
+++ b/frontend/src/components/common/index.js
@@ -4,3 +4,4 @@ export { default as Card } from './Card';
 export { default as SearchBar } from './SearchBar';
 export { default as Badge } from './Badge';
 export { default as Navigation } from './Navigation';
+export { default as ScoreCards } from './ScoreCards';

--- a/frontend/src/components/common/index.js
+++ b/frontend/src/components/common/index.js
@@ -5,3 +5,5 @@ export { default as SearchBar } from './SearchBar';
 export { default as Badge } from './Badge';
 export { default as Navigation } from './Navigation';
 export { default as ScoreCards } from './ScoreCards';
+export { default as LoadingSpinner } from './LoadingSpinner';
+export { default as EmptyState } from './EmptyState';

--- a/frontend/src/features/Diagnose/components/DiagnoseSearchSection.jsx
+++ b/frontend/src/features/Diagnose/components/DiagnoseSearchSection.jsx
@@ -1,0 +1,97 @@
+import React, { useState, useEffect } from "react";
+import PropTypes from "prop-types";
+import { Button, SearchBar } from "../../../components/common";
+
+const DiagnoseSearchSection = ({ onSearch, error }) => {
+    const [searchInput, setSearchInput] = useState("");
+    const [showButton, setShowButton] = useState(false);
+
+    useEffect(() => {
+        const handleResize = () => {
+            setShowButton(window.innerWidth >= 1024);
+        };
+
+        handleResize();
+        window.addEventListener('resize', handleResize);
+        
+        return () => window.removeEventListener('resize', handleResize);
+    }, []);
+
+    const handleSearch = () => {
+        if (searchInput.trim()) {
+            onSearch(searchInput.trim());
+        }
+
+        alert("진단을 시작합니다!"); // 진단 시작 알림
+        setSearchInput(""); // 검색 후 입력창 초기화
+    };
+
+    const handleKeyDown = (e) => {
+        if (e.key === "Enter") {
+            handleSearch();
+        }
+    };
+
+    return (
+        <section className="bg-[#F3F3F3] py-16">
+            <div className="container mx-auto px-6 xl:px-8 2xl:px-12">
+                <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-6 md:gap-8">
+                    {/* 제목 섹션 */}
+                    <div className="flex-shrink-0 text-center md:text-left">
+                        <h1 className="text-2xl md:text-xl lg:text-2xl font-bold text-gray-900 mb-1">
+                            OSS 프로젝트 진단하기
+                        </h1>
+                        <p className="text-sm md:text-xs lg:text-sm text-gray-600">
+                            GitHub Repository URL을 입력하여 분석 결과를 확인하세요.
+                        </p>
+                    </div>
+
+                    {/* 검색 영역 */}
+                    <div className="flex-1 max-w-2xl">
+                        <div className="space-y-2">
+                            <div className="flex gap-2">
+                                <SearchBar
+                                    placeholder="GitHub Repository URL"
+                                    value={searchInput}
+                                    onChange={setSearchInput}
+                                    onKeyDown={handleKeyDown}
+                                    onSubmit={handleSearch}
+                                    size="large"
+                                    className="flex-1"
+                                />
+                                
+                                {showButton && (
+                                    <Button
+                                        onClick={handleSearch}
+                                        variant="primary"
+                                        size="large"
+                                    >
+                                        진단하기
+                                    </Button>
+                                )}
+                            </div>
+                            
+                            {/* 안내 메시지 */}
+                            <div className="text-xs text-center md:text-left">
+                                {error ? (
+                                    <span className="text-red-500">{error}</span>
+                                ) : (
+                                    <span className="text-gray-500">
+                                        예시: https://github.com/facebook/react 또는 facebook/react
+                                    </span>
+                                )}
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+    );
+};
+
+DiagnoseSearchSection.propTypes = {
+    onSearch: PropTypes.func.isRequired,
+    error: PropTypes.string
+};
+
+export default DiagnoseSearchSection;

--- a/frontend/src/features/Diagnose/components/DiagnoseSearchSection.jsx
+++ b/frontend/src/features/Diagnose/components/DiagnoseSearchSection.jsx
@@ -35,7 +35,8 @@ const DiagnoseSearchSection = ({ onSearch, error }) => {
     return (
         <section className="bg-[#F3F3F3] py-16">
             <div className="container mx-auto px-6 xl:px-8 2xl:px-12">
-                <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-6 md:gap-8">
+                <div className="max-w-7xl mx-auto">
+                    <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-6 md:gap-8">
                     {/* 제목 섹션 */}
                     <div className="flex-shrink-0 text-center md:text-left">
                         <h1 className="text-2xl md:text-xl lg:text-2xl font-bold text-gray-900 mb-1">
@@ -82,14 +83,13 @@ const DiagnoseSearchSection = ({ onSearch, error }) => {
                                 )}
                             </div>
                         </div>
+                        </div>
                     </div>
                 </div>
             </div>
         </section>
     );
-};
-
-DiagnoseSearchSection.propTypes = {
+};DiagnoseSearchSection.propTypes = {
     onSearch: PropTypes.func.isRequired,
     error: PropTypes.string
 };

--- a/frontend/src/features/Diagnose/components/DiagnoseTabContent.jsx
+++ b/frontend/src/features/Diagnose/components/DiagnoseTabContent.jsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { LoadingSpinner, EmptyState, Button } from '../../../components/common';
+// import OverallOverview from './OverallOverview';
+
+
+const DiagnoseTabContent = ({ activeTab, loading, projectData, fullProjectName }) => {
+    // 로딩 중일 때
+    if (loading) {
+        return (
+            <LoadingSpinner
+                message={`${fullProjectName} 프로젝트를 분석 중입니다. 잠시만 기다려 주세요...`}
+                size="large"
+                color="blue"
+            />
+        );
+    }
+
+    // 프로젝트 데이터 없을 때
+    // if (!projectData) {
+    //     return (
+    //         <EmptyState
+    //             title="프로젝트 데이터를 찾을 수 없습니다."
+    //             message="진단 결과가 없습니다. 프로젝트를 다시 확인해 주세요."
+    //             action={
+    //                 <Button
+    //                     onClick={() => window.location.reload()}
+    //                     variant="primary"
+    //                 >
+    //                     다시 시도하기
+    //                 </Button>
+    //             }
+    //         />
+    //     );
+    // }
+
+    // 활성화된 탭에 따라 다른 컴포넌트 렌더링
+    const renderTabContent = () => {
+        switch (activeTab) {
+            case 'overview':
+                // return <OverallOverview projectData={projectData} />;
+                return <div>종합 점수 탭 내용</div>; // 임시 내용
+            case 'health':
+                return <div>건강 점수 탭 내용</div>; // 임시 내용
+            case 'security':
+                return <div>보안 점수 탭 내용</div>; // 임시 내용
+            default:
+                return <div>종합 점수 탭 내용</div>; // 임시 내용
+        }
+    };
+
+    return (
+        <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
+            {renderTabContent()}
+        </div>
+    );
+};
+
+DiagnoseTabContent.propTypes = {
+    activeTab: PropTypes.string.isRequired,
+    loading: PropTypes.bool.isRequired,
+    projectData: PropTypes.object,
+    fullProjectName: PropTypes.string.isRequired
+};
+
+export default DiagnoseTabContent;

--- a/frontend/src/features/Diagnose/components/ProjectInfo.jsx
+++ b/frontend/src/features/Diagnose/components/ProjectInfo.jsx
@@ -1,0 +1,110 @@
+import React from "react";
+import { StarIcon, CodeBracketIcon, EyeIcon } from "@heroicons/react/24/solid";
+import { Badge } from "../../../components/common";
+
+const ProjectInfo = () => {
+    // Mock Data
+    const projectData = {
+        name: "react-awesome-project",
+        description: "A modern React application with TypeScript, Tailwind CSS, and comprehensive testing suite. This project demonstrates best practices in frontend development including component architecture, state management, and responsive design patterns.",
+        owner: {
+            name: "awesome-developer",
+            avatar: "https://via.placeholder.com/120x120/4F46E5/FFFFFF?text=AD"
+        },
+        stats: {
+            stars: 1247,
+            forks: 234,
+            watchers: 89
+        },
+        language: "TypeScript",
+        license: "MIT",
+        lastPush: "2024-01-15",
+        topics: ["react", "typescript", "tailwind", "vite"]
+    };
+
+    return (
+        <div className="bg-white p-4 md:p-6 border-b border-gray-200">
+            <div className="flex flex-col lg:flex-row lg:items-start lg:gap-6">
+                {/* Project Image - visible on large screens only */}
+                <div className="hidden lg:block lg:flex-shrink-0">
+                    <div className="w-32 h-32 bg-gray-200 rounded-lg flex items-center justify-center">
+                        <div className="text-gray-400 text-xs text-center">
+                            <CodeBracketIcon className="w-8 h-8 mx-auto mb-2" />
+                            <span>프로젝트 이미지</span>
+                        </div>
+                    </div>
+                </div>
+
+                {/* Project Information */}
+                <div className="flex-1 min-w-0">
+                    <div className="mb-3">
+                        <div className="flex items-center gap-3 mb-2">
+                            <h2 className="text-lg font-bold text-gray-900 break-words">
+                                {projectData.name}
+                            </h2>
+                            <Badge variant="info" size="small">
+                                {projectData.license}
+                            </Badge>
+                        </div>
+
+                        <div className="flex items-center gap-2 mb-2">
+                            <div className="w-4 h-4 bg-gray-300 rounded-full flex items-center justify-center overflow-hidden flex-shrink-0">
+                                <img
+                                    src={projectData.owner.avatar}
+                                    alt={`${projectData.owner.name} avatar`}
+                                    className="w-full h-full object-cover"
+                                />
+                            </div>
+                            <span className="text-xs text-gray-600">
+                                {projectData.owner.name}
+                            </span>
+                        </div>
+                    </div>
+
+                    <p className="text-gray-600 text-xs leading-relaxed mb-2 line-clamp-3">
+                        {projectData.description}
+                    </p>
+
+                    <div className="flex flex-wrap items-center gap-3 mb-3 text-sm text-gray-500">
+                        <span>Last Push: {projectData.lastPush}</span>
+
+                        <div className="flex items-center gap-1">
+                            <StarIcon className="w-4 h-4" />
+                            <span>{projectData.stats.stars.toLocaleString()}</span>
+                        </div>
+
+                        <div className="flex items-center gap-1">
+                            <CodeBracketIcon className="w-4 h-4" />
+                            <span>{projectData.stats.forks.toLocaleString()}</span>
+                        </div>
+
+                        <div className="flex items-center gap-1">
+                            <EyeIcon className="w-3 h-3" />
+                            <span>{projectData.stats.watchers.toLocaleString()}</span>
+                        </div>
+                    </div>
+
+                    <div className="flex flex-wrap items-center gap-2 mb-3">
+                        
+                        <Badge variant="secondary" size="small">
+                            {projectData.language}
+                        </Badge>
+
+                        {projectData.topics.slice(0, 3).map((topic, index) => (
+                            <Badge key={index} variant="default" size="small">
+                                {topic}
+                            </Badge>
+                        ))}
+                        {projectData.topics.length > 3 && (
+                            <Badge variant="outline" size="small">
+                                +{projectData.topics.length - 3}
+                            </Badge>
+                        )}
+                    </div>
+                </div>
+            </div>
+        </div>
+    )
+}
+
+export default ProjectInfo;

--- a/frontend/src/features/Diagnose/pages/DiagnosePage.jsx
+++ b/frontend/src/features/Diagnose/pages/DiagnosePage.jsx
@@ -1,11 +1,31 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { Layout } from '../../../components/layout';
+import ProjectInfo from '../components/ProjectInfo';
+import DiagnoseSearchSection from '../components/DiagnoseSearchSection';
+import DiagnoseTabContent from '../components/DiagnoseTabContent';
+import { ScoreCards } from '../../../components/common';
 
 const Diagnose = () => {
+    const [activeTab, setActiveTab] = useState('overview');
+
     return (
-        <div className="diagnose-page">
-            <h1>진단 페이지</h1>
-            <p>여기에 진단 기능이 구현됩니다.</p>
-        </div>
+        <Layout>
+            <div className="min-h-screen">
+                {/* Header */}
+                <DiagnoseSearchSection onSearch={() => { }} error={null} />
+
+                {/* Main */}
+                <div className="bg-white">
+                    <div className="container mx-auto px-6 xl:px-8 2xl:px-12 py-6">
+                        <div className="max-w-7xl mx-auto space-y-6">
+                            <ProjectInfo />
+                            <ScoreCards scores={{}} activeTab={activeTab} onTabChange={setActiveTab} variant='diagnose' />
+                            <DiagnoseTabContent activeTab={activeTab} loading={false} projectData={null} fullProjectName={''} />
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </Layout>
     );
 }
 


### PR DESCRIPTION
### 작업 내용
- DiagnosePage ProjectInfo, HeaderSection 구현
- Diagnose Tab 동작 UI 컴포넌트 추가
- 데이터 로딩 중 / 검색 결과 없음 대응 공통 UI 컴포넌트 추가 (EmptyState, Spinner)
- Badge UI 상태 및 색상 반응 개선
- Diagnose Header 반응형 개선

### 목적
- 진단 페이지의 초기 UI 구축 및 공통 컴포넌트 재사용성 확장
- 사용자 경험 향상을 위한 빈 상태/로딩 대응

## 테스트
- 로컬에서 UI 정상 동작 확인
- 로딩, Empty, 데이터 존재 시 UI 확인 완료


https://github.com/user-attachments/assets/b835954b-5dd2-4cbe-9bfc-924217b410f6
https://github.com/user-attachments/assets/754eb6db-e591-451c-b076-cdabe6cacc8b
