### PR TITLE
[Add] 활동 리더보드 Backend API 구현 및 Frontend API 연동

### DIFF
--- a/backend/src/main/java/com/ossdoctor/DTO/LeaderboardUserDTO.java
+++ b/backend/src/main/java/com/ossdoctor/DTO/LeaderboardUserDTO.java
@@ -1,0 +1,26 @@
+package com.ossdoctor.DTO;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class LeaderboardUserDTO {
+    private Long userId;
+    private String username;
+    private String nickname;
+    private String avatar;
+    private Integer totalScore;
+    private Integer prCount;
+    private Integer issueCount;
+    private Integer commitsCount;
+    private Integer contributionStreak;
+    private LocalDateTime joinDate;
+    private Integer rank; // 순위 (계산된 값)
+}

--- a/backend/src/main/java/com/ossdoctor/Repository/ContributionRepository.java
+++ b/backend/src/main/java/com/ossdoctor/Repository/ContributionRepository.java
@@ -1,12 +1,14 @@
 package com.ossdoctor.Repository;
 
 import com.ossdoctor.Entity.ContributionEntity;
+import com.ossdoctor.Entity.REFERENCE_TYPE;
 import com.ossdoctor.Entity.UserEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -36,4 +38,34 @@ public interface ContributionRepository extends JpaRepository<ContributionEntity
         @Param("number") Integer number, 
         @Param("referenceType") com.ossdoctor.Entity.REFERENCE_TYPE referenceType
     );
+
+    // 리더보드용 쿼리들 추가
+    
+    // 특정 사용자의 기간별 커밋 수 조회
+    @Query("SELECT COUNT(c) FROM ContributionEntity c WHERE c.user.idx = :userId AND c.referenceType = 'COMMIT' AND c.contributedAt >= :fromDate AND c.contributedAt <= :toDate")
+    int countCommitsByUserAndDateRange(
+        @Param("userId") Long userId, 
+        @Param("fromDate") LocalDateTime fromDate, 
+        @Param("toDate") LocalDateTime toDate
+    );
+
+    // 특정 사용자의 기간별 PR 수 조회
+    @Query("SELECT COUNT(c) FROM ContributionEntity c WHERE c.user.idx = :userId AND c.referenceType = 'PR' AND c.contributedAt >= :fromDate AND c.contributedAt <= :toDate")
+    int countPRsByUserAndDateRange(
+        @Param("userId") Long userId, 
+        @Param("fromDate") LocalDateTime fromDate, 
+        @Param("toDate") LocalDateTime toDate
+    );
+
+    // 특정 사용자의 기간별 이슈 수 조회
+    @Query("SELECT COUNT(c) FROM ContributionEntity c WHERE c.user.idx = :userId AND c.referenceType = 'ISSUE' AND c.contributedAt >= :fromDate AND c.contributedAt <= :toDate")
+    int countIssuesByUserAndDateRange(
+        @Param("userId") Long userId, 
+        @Param("fromDate") LocalDateTime fromDate, 
+        @Param("toDate") LocalDateTime toDate
+    );
+
+    // 특정 사용자의 연속 기여 일수 계산용 - 기여 엔티티들 조회해서 날짜 변환은 서비스에서 처리
+    @Query("SELECT c FROM ContributionEntity c WHERE c.user.idx = :userId ORDER BY c.contributedAt DESC")
+    List<ContributionEntity> findContributionsByUser(@Param("userId") Long userId);
 }

--- a/backend/src/main/java/com/ossdoctor/Service/LeaderboardService.java
+++ b/backend/src/main/java/com/ossdoctor/Service/LeaderboardService.java
@@ -1,0 +1,225 @@
+package com.ossdoctor.Service;
+
+import com.ossdoctor.DTO.LeaderboardUserDTO;
+import com.ossdoctor.DTO.UserDTO;
+import com.ossdoctor.Entity.ContributionEntity;
+import com.ossdoctor.Entity.UserEntity;
+import com.ossdoctor.Repository.ContributionRepository;
+import com.ossdoctor.Repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class LeaderboardService {
+
+    private final UserRepository userRepository;
+    private final UserService userService;
+    private final ContributionRepository contributionRepository;
+
+    /**
+     * 기간별 리더보드 조회
+     * @param period today, week, month
+     * @param limit 조회할 사용자 수
+     * @return 리더보드 데이터
+     */
+    public List<LeaderboardUserDTO> getLeaderboard(String period, int limit) {
+        log.info("리더보드 조회 시작 - 기간: {}, 제한: {}", period, limit);
+        
+        // 전체 기여 데이터 수 확인
+        long totalContributions = contributionRepository.count();
+        log.info("데이터베이스 전체 기여 데이터 수: {}", totalContributions);
+        
+        // 기간에 따른 날짜 계산
+        LocalDateTime fromDate = calculateFromDate(period);
+        LocalDateTime toDate = LocalDateTime.now();
+        
+        log.debug("조회 기간: {} ~ {}", fromDate, toDate);
+        
+        // totalScore 기준으로 상위 사용자 조회
+        PageRequest pageRequest = PageRequest.of(0, limit, Sort.by(Sort.Direction.DESC, "totalScore"));
+        List<UserEntity> users = userRepository.findTopUsersByScore(pageRequest);
+        
+        log.info("조회된 사용자 수: {}", users.size());
+        
+        // LeaderboardUserDTO로 변환하고 순위 추가 (실제 기여 데이터 포함)
+        AtomicInteger rank = new AtomicInteger(1);
+        return users.stream()
+                .map(user -> convertToLeaderboardDTOWithRealData(user, rank.getAndIncrement(), fromDate, toDate))
+                .toList();
+    }
+
+    /**
+     * 특정 사용자의 순위 조회
+     * @param nickname 사용자 닉네임
+     * @param period 기간
+     * @return 사용자 순위 정보
+     */
+    public LeaderboardUserDTO getUserRank(String nickname, String period) {
+        log.info("사용자 순위 조회 시작 - 닉네임: {}, 기간: {}", nickname, period);
+        
+        Optional<UserDTO> userOpt = userService.findByUsername(nickname);
+        if (userOpt.isEmpty()) {
+            log.warn("사용자를 찾을 수 없음: {}", nickname);
+            return null;
+        }
+        
+        UserDTO user = userOpt.get();
+        
+        // 해당 사용자보다 점수가 높은 사용자 수를 계산해서 순위 도출
+        int higherScoreCount = userRepository.countUsersWithHigherScore(user.getTotalScore());
+        int userRank = higherScoreCount + 1;
+        
+        // 기간에 따른 날짜 계산
+        LocalDateTime fromDate = calculateFromDate(period);
+        LocalDateTime toDate = LocalDateTime.now();
+        
+        log.info("사용자 {} 의 순위: {}", nickname, userRank);
+        
+        return LeaderboardUserDTO.builder()
+                .userId(user.getIdx())
+                .username(user.getNickname())
+                .nickname(user.getNickname())
+                .avatar(user.getAvatarUrl())
+                .totalScore(user.getTotalScore())
+                .prCount(calculateRealPRCount(user.getIdx(), fromDate, toDate))
+                .issueCount(calculateRealIssueCount(user.getIdx(), fromDate, toDate))
+                .commitsCount(calculateRealCommitsCount(user.getIdx(), fromDate, toDate))
+                .contributionStreak(calculateRealContributionStreak(user.getIdx()))
+                .joinDate(user.getJoinedAt())
+                .rank(userRank)
+                .build();
+    }
+
+    /**
+     * 기간에 따른 시작 날짜 계산
+     */
+    private LocalDateTime calculateFromDate(String period) {
+        LocalDateTime now = LocalDateTime.now();
+        
+        return switch (period.toLowerCase()) {
+            case "today" -> now.truncatedTo(ChronoUnit.DAYS); // 오늘 00:00:00
+            case "week" -> now.minusDays(now.getDayOfWeek().getValue() - 1).truncatedTo(ChronoUnit.DAYS); // 이번 주 월요일 00:00:00
+            case "month" -> now.withDayOfMonth(1).truncatedTo(ChronoUnit.DAYS); // 이번 달 1일 00:00:00
+            default -> now.minusDays(1).truncatedTo(ChronoUnit.DAYS); // 기본값은 오늘
+        };
+    }
+
+    /**
+     * UserEntity를 LeaderboardUserDTO로 변환 (실제 기여 데이터 포함)
+     */
+    private LeaderboardUserDTO convertToLeaderboardDTOWithRealData(UserEntity user, int rank, LocalDateTime fromDate, LocalDateTime toDate) {
+        log.info("사용자 {} (ID: {}) 데이터 변환 시작", user.getNickname(), user.getIdx());
+        
+        return LeaderboardUserDTO.builder()
+                .userId(user.getIdx())
+                .username(user.getNickname())
+                .nickname(user.getNickname())
+                .avatar(user.getAvatarUrl())
+                .totalScore(user.getTotalScore())
+                .prCount(calculateRealPRCount(user.getIdx(), fromDate, toDate))
+                .issueCount(calculateRealIssueCount(user.getIdx(), fromDate, toDate))
+                .commitsCount(calculateRealCommitsCount(user.getIdx(), fromDate, toDate))
+                .contributionStreak(calculateRealContributionStreak(user.getIdx()))
+                .joinDate(user.getJoinedAt())
+                .rank(rank)
+                .build();
+    }
+
+    // 실제 데이터베이스에서 기여 데이터 계산하는 메소드들
+
+    /**
+     * 실제 PR 수 계산
+     */
+    private Integer calculateRealPRCount(Long userId, LocalDateTime fromDate, LocalDateTime toDate) {
+        try {
+            int count = contributionRepository.countPRsByUserAndDateRange(userId, fromDate, toDate);
+            log.info("사용자 {} PR 수: {} (기간: {} ~ {})", userId, count, fromDate, toDate);
+            return count;
+        } catch (Exception e) {
+            log.warn("PR 수 계산 실패 for user {}: {}", userId, e.getMessage());
+            return 0;
+        }
+    }
+
+    /**
+     * 실제 이슈 수 계산
+     */
+    private Integer calculateRealIssueCount(Long userId, LocalDateTime fromDate, LocalDateTime toDate) {
+        try {
+            int count = contributionRepository.countIssuesByUserAndDateRange(userId, fromDate, toDate);
+            log.info("사용자 {} 이슈 수: {} (기간: {} ~ {})", userId, count, fromDate, toDate);
+            return count;
+        } catch (Exception e) {
+            log.warn("이슈 수 계산 실패 for user {}: {}", userId, e.getMessage());
+            return 0;
+        }
+    }
+
+    /**
+     * 실제 커밋 수 계산
+     */
+    private Integer calculateRealCommitsCount(Long userId, LocalDateTime fromDate, LocalDateTime toDate) {
+        try {
+            int count = contributionRepository.countCommitsByUserAndDateRange(userId, fromDate, toDate);
+            log.info("사용자 {} 커밋 수: {} (기간: {} ~ {})", userId, count, fromDate, toDate);
+            return count;
+        } catch (Exception e) {
+            log.warn("커밋 수 계산 실패 for user {}: {}", userId, e.getMessage());
+            return 0;
+        }
+    }
+
+    /**
+     * 실제 연속 기여 일수 계산
+     */
+    private Integer calculateRealContributionStreak(Long userId) {
+        try {
+            List<ContributionEntity> contributions = contributionRepository.findContributionsByUser(userId);
+            
+            if (contributions.isEmpty()) {
+                log.info("사용자 {} 기여 데이터 없음", userId);
+                return 0;
+            }
+            
+            // 엔티티에서 날짜만 추출하고 중복 제거 및 정렬
+            List<LocalDate> uniqueDates = contributions.stream()
+                    .map(c -> c.getContributedAt().toLocalDate())
+                    .distinct()
+                    .sorted((d1, d2) -> d2.compareTo(d1)) // 최신 날짜부터
+                    .toList();
+            
+            // 연속 일수 계산
+            int streak = 0;
+            LocalDate today = LocalDate.now();
+            LocalDate checkDate = today;
+            
+            // 오늘부터 시작해서 연속으로 기여한 날짜를 찾음
+            for (LocalDate contributionDate : uniqueDates) {
+                if (contributionDate.equals(checkDate) || contributionDate.equals(checkDate.minusDays(1))) {
+                    streak++;
+                    checkDate = contributionDate.minusDays(1);
+                } else {
+                    break;
+                }
+            }
+            
+            log.info("사용자 {} 연속 기여 일수: {}", userId, streak);
+            return streak;
+        } catch (Exception e) {
+            log.warn("연속 기여 일수 계산 실패 for user {}: {}", userId, e.getMessage());
+            return 0;
+        }
+    }
+}

--- a/backend/src/main/java/com/ossdoctor/controller/LeaderboardController.java
+++ b/backend/src/main/java/com/ossdoctor/controller/LeaderboardController.java
@@ -1,0 +1,90 @@
+package com.ossdoctor.controller;
+
+import com.ossdoctor.DTO.LeaderboardUserDTO;
+import com.ossdoctor.Service.LeaderboardService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/leaderboard")
+@RequiredArgsConstructor
+public class LeaderboardController {
+
+    private final LeaderboardService leaderboardService;
+
+    /**
+     * 기간별 리더보드 조회
+     * @param period today(오늘), week(이번주), month(이번달)
+     * @param limit 조회할 사용자 수 (기본 10명)
+     * @return 리더보드 데이터
+     */
+    @GetMapping("/{period}")
+    public ResponseEntity<Map<String, Object>> getLeaderboard(
+            @PathVariable String period,
+            @RequestParam(defaultValue = "10") int limit) {
+        
+        try {
+            log.info("리더보드 조회 요청 - 기간: {}, 제한: {}", period, limit);
+            
+            List<LeaderboardUserDTO> leaderboard = leaderboardService.getLeaderboard(period, limit);
+            
+            return ResponseEntity.ok().body(Map.of(
+                    "success", true,
+                    "data", leaderboard,
+                    "period", period,
+                    "totalCount", leaderboard.size()
+            ));
+            
+        } catch (Exception e) {
+            log.error("리더보드 조회 실패 - 기간: {}, 오류: {}", period, e.getMessage(), e);
+            return ResponseEntity.badRequest().body(Map.of(
+                    "success", false,
+                    "error", "리더보드 데이터를 불러올 수 없습니다."
+            ));
+        }
+    }
+
+    /**
+     * 특정 사용자의 순위 조회
+     * @param nickname 사용자 닉네임
+     * @param period 기간 (today, week, month)
+     * @return 사용자 순위 정보
+     */
+    @GetMapping("/rank/{nickname}")
+    public ResponseEntity<Map<String, Object>> getUserRank(
+            @PathVariable String nickname,
+            @RequestParam(defaultValue = "today") String period) {
+        
+        try {
+            log.info("사용자 순위 조회 요청 - 닉네임: {}, 기간: {}", nickname, period);
+            
+            LeaderboardUserDTO userRank = leaderboardService.getUserRank(nickname, period);
+            
+            if (userRank == null) {
+                return ResponseEntity.ok().body(Map.of(
+                        "success", false,
+                        "message", "사용자를 찾을 수 없습니다."
+                ));
+            }
+            
+            return ResponseEntity.ok().body(Map.of(
+                    "success", true,
+                    "data", userRank,
+                    "period", period
+            ));
+            
+        } catch (Exception e) {
+            log.error("사용자 순위 조회 실패 - 닉네임: {}, 오류: {}", nickname, e.getMessage(), e);
+            return ResponseEntity.badRequest().body(Map.of(
+                    "success", false,
+                    "error", "사용자 순위를 불러올 수 없습니다."
+            ));
+        }
+    }
+}

--- a/frontend/src/features/Ecosystem/api/leaderboardApi.js
+++ b/frontend/src/features/Ecosystem/api/leaderboardApi.js
@@ -1,0 +1,84 @@
+import { apiClient } from '../../../utils/api-client';
+
+/**
+ * 리더보드 데이터 조회
+ * @param {string} period - 기간 (today, week, month)
+ * @param {number} limit - 조회할 사용자 수
+ * @returns {Promise<Object>} 리더보드 데이터
+ */
+export const getLeaderboard = async (period = 'today', limit = 10) => {
+    try {
+        const timestamp = Date.now();
+        const response = await apiClient(`/api/leaderboard/${period}?limit=${limit}&t=${timestamp}`);
+        return response;
+    } catch (error) {
+        console.error('리더보드 조회 실패:', error);
+        throw error;
+    }
+};
+
+/**
+ * 특정 사용자의 순위 조회
+ * @param {string} nickname - 사용자 닉네임
+ * @param {string} period - 기간 (today, week, month)
+ * @returns {Promise<Object>} 사용자 순위 정보
+ */
+export const getUserRank = async (nickname, period = 'today') => {
+    try {
+        const timestamp = Date.now();
+        const response = await apiClient(`/api/leaderboard/rank/${nickname}?period=${period}&t=${timestamp}`);
+        return response;
+    } catch (error) {
+        console.error('사용자 순위 조회 실패:', error);
+        throw error;
+    }
+};
+
+/**
+ * 백엔드 리더보드 데이터를 프론트엔드 형식으로 변환
+ * @param {Object} backendData - 백엔드에서 받은 리더보드 데이터
+ * @returns {Array} 프론트엔드 형식의 리더보드 데이터
+ */
+export const transformLeaderboardData = (backendData) => {
+    if (!backendData || !backendData.success || !backendData.data) {
+        return [];
+    }
+
+    return backendData.data.map(user => ({
+        rank: user.rank,
+        username: user.username || user.nickname,
+        avatar: user.avatar,
+        avatarUrl: user.avatar, // avatar 필드를 avatarUrl로도 매핑
+        totalScore: user.totalScore,
+        prCount: user.prCount,
+        issueCount: user.issueCount,
+        commitsCount: user.commitsCount,
+        contributionStreak: user.contributionStreak,
+        joinDate: user.joinDate
+    }));
+};
+
+/**
+ * 백엔드 사용자 순위 데이터를 프론트엔드 형식으로 변환
+ * @param {Object} backendData - 백엔드에서 받은 사용자 순위 데이터
+ * @returns {Object} 프론트엔드 형식의 사용자 순위 데이터
+ */
+export const transformUserRankData = (backendData) => {
+    if (!backendData || !backendData.success || !backendData.data) {
+        return null;
+    }
+
+    const user = backendData.data;
+    return {
+        rank: user.rank,
+        username: user.username || user.nickname,
+        avatar: user.avatar,
+        avatarUrl: user.avatar, // avatar 필드를 avatarUrl로도 매핑
+        totalScore: user.totalScore,
+        prCount: user.prCount,
+        issueCount: user.issueCount,
+        commitsCount: user.commitsCount,
+        contributionStreak: user.contributionStreak,
+        joinDate: user.joinDate
+    };
+};

--- a/frontend/src/features/Ecosystem/components/ActivityLeaderboard.jsx
+++ b/frontend/src/features/Ecosystem/components/ActivityLeaderboard.jsx
@@ -3,9 +3,12 @@ import PropTypes from 'prop-types';
 import { ArrowLeftIcon } from '@heroicons/react/24/outline';
 import { Button, EmptyState, LoadingSpinner } from '../../../components/common';
 import useLeaderboardData from '../hooks/useLeaderboardData';
+import { useAuth } from '../../../hooks/useAuth';
+import { initiateGitHubLogin } from '../../../utils/github-auth';
 
 const ActivityLeaderboard = ({ onBack }) => {
-    const [timePeriod, setTimePeriod] = useState('realtime');
+    const [timePeriod, setTimePeriod] = useState('today'); // 'realtime' -> 'today'로 변경
+    const { isAuthenticated } = useAuth();
 
     const {
         leaderboardData,
@@ -17,6 +20,12 @@ const ActivityLeaderboard = ({ onBack }) => {
     const handleTimePeriodChange = (period) => {
         setTimePeriod(period);
     }
+
+    const handleLoginClick = () => {
+        initiateGitHubLogin({
+            redirectAfterLogin: '/ecosystem' // 로그인 후 생태계 페이지로 리디렉션
+        });
+    };
 
     // 로딩 상태 처리 - 로딩 중일 때 스피너 표시
     if (loading && !leaderboardData.length) {
@@ -74,13 +83,13 @@ const ActivityLeaderboard = ({ onBack }) => {
                             <span className="text-sm text-gray-600 whitespace-nowrap">기간 설정:</span>
                             <div className="flex bg-gray-100 rounded-lg p-1">
                                 <button
-                                    onClick={() => handleTimePeriodChange('realtime')}
-                                    className={`px-3 py-1 text-sm rounded-md transition-colors ${timePeriod === 'realtime'
+                                    onClick={() => handleTimePeriodChange('today')}
+                                    className={`px-3 py-1 text-sm rounded-md transition-colors ${timePeriod === 'today'
                                         ? 'bg-white text-gray-900 shadow-sm'
                                         : 'text-gray-600 hover:text-gray-900'
                                         }`}
                                 >
-                                    실시간
+                                    오늘
                                 </button>
                                 <button
                                     onClick={() => handleTimePeriodChange('week')}
@@ -186,28 +195,67 @@ const ActivityLeaderboard = ({ onBack }) => {
                 {/* 나의 랭킹 */}
                 <div className="bg-blue-50 border border-blue-200 rounded-lg p-6">
                     <h3 className="text-lg font-semibold mb-4 text-blue-800">나의 랭킹은?</h3>
-                    <div className="flex items-center justify-between">
-                        <div className="flex items-center space-x-4">
-                            {/* 아바타 */}
-                            <div className="w-12 h-12 bg-yellow-100 rounded-full flex items-center justify-center overflow-hidden">
-                                <span className="text-2xl">😊</span>
+                    
+                    {isAuthenticated && currentUser ? (
+                        /* 로그인된 상태 - 사용자 랭킹 정보 표시 */
+                        <div className="flex items-center justify-between">
+                            <div className="flex items-center space-x-4">
+                                {/* 아바타 */}
+                                <div className="w-12 h-12 bg-yellow-100 rounded-full flex items-center justify-center overflow-hidden">
+                                    {currentUser.avatarUrl ? (
+                                        <img 
+                                            src={currentUser.avatarUrl} 
+                                            alt={currentUser.username}
+                                            className="w-full h-full object-cover"
+                                        />
+                                    ) : (
+                                        <span className="text-2xl">😊</span>
+                                    )}
+                                </div>
+
+                                {/* 사용자 정보 */}
+                                <div>
+                                    <div className="font-semibold text-lg">{currentUser.username}</div>
+                                    <div className="text-gray-500 text-sm">GitHub Username</div>
+                                    {currentUser.rank && (
+                                        <div className="text-blue-600 text-sm font-medium">
+                                            전체 순위: {currentUser.rank}위
+                                        </div>
+                                    )}
+                                </div>
                             </div>
 
-                            {/* 사용자 정보 */}
-                            <div>
-                                <div className="font-semibold text-lg">{currentUser.username}</div>
-                                <div className="text-gray-500 text-sm">GitHub Username</div>
+                            {/* 랭킹과 점수 */}
+                            <div className="text-right">
+                                <div className="font-bold text-lg mb-1">Score: {currentUser.totalScore?.toLocaleString() || 0}</div>
+                                <div className="text-sm text-gray-600">
+                                    Commits: {currentUser.commitsCount || 0} | PRs: {currentUser.prCount || 0} | Issues: {currentUser.issueCount || 0}
+                                </div>
                             </div>
                         </div>
-
-                        {/* 랭킹과 점수 */}
-                        <div className="text-right">
-                            <div className="font-bold text-lg mb-1">Score: {currentUser.totalScore.toLocaleString()}</div>
-                            <div className="text-sm text-gray-600">
-                                Commits: {currentUser.commitsCount} | PRs: {currentUser.prCount} | Issues: {currentUser.issueCount}
+                    ) : (
+                        /* 로그인하지 않은 상태 - 로그인 유도 */
+                        <div className="text-center py-8">
+                            <div className="mb-4">
+                                <div className="w-16 h-16 bg-gray-200 rounded-full flex items-center justify-center mx-auto mb-3">
+                                    <span className="text-2xl">🔒</span>
+                                </div>
+                                <h4 className="text-lg font-semibold text-gray-700 mb-2">
+                                    나의 순위를 확인하고 싶나요?
+                                </h4>
+                                <p className="text-gray-500 text-sm mb-6">
+                                    로그인하면 나의 활동 점수와 순위를 확인할 수 있습니다.
+                                </p>
                             </div>
+                            <Button 
+                                onClick={handleLoginClick}
+                                variant="primary"
+                                className="bg-blue-600 hover:bg-blue-700 text-white px-6 py-2"
+                            >
+                                GitHub으로 로그인하기
+                            </Button>
                         </div>
-                    </div>
+                    )}
                 </div>
             </div>
         </div>

--- a/frontend/src/features/Ecosystem/hooks/useLeaderboardData.js
+++ b/frontend/src/features/Ecosystem/hooks/useLeaderboardData.js
@@ -1,56 +1,111 @@
-import { useState, useMemo } from 'react';
+import { useState, useEffect } from 'react';
+import { useAuth } from '../../../hooks/useAuth';
+import { getLeaderboard, getUserRank, transformLeaderboardData, transformUserRankData } from '../api/leaderboardApi';
 import { MOCK_LEADERBOARD_DATA, MOCK_CURRENT_USER } from '../mockData';
 
 /**
  * 리더보드 데이터를 관리하는 훅
- * @param {string} timePeriod - 리더보드 데이터의 시간 범위 ('realtime', 'week', 'month')
+ * @param {string} timePeriod - 리더보드 데이터의 시간 범위 ('today', 'week', 'month')
  * @return {Object} 리더보드 데이터와 관련된 함수들
  */
-
-const useLeaderboardData = (timePeriod = 'realtime') => {
-    const [loading, setLoading] = useState(false);
+const useLeaderboardData = (timePeriod = 'today') => {
+    const { user, isAuthenticated } = useAuth();
+    const [loading, setLoading] = useState(true);
     const [error, setError] = useState('');
+    const [leaderboardData, setLeaderboardData] = useState([]);
+    const [currentUser, setCurrentUser] = useState(null);
+
+    // 기간 매핑 (UI용 -> API용)
+    const mapTimePeriod = (period) => {
+        const periodMap = {
+            'today': 'today',    // 오늘
+            'week': 'week',      // 이번 주  
+            'month': 'month'     // 이번 달
+        };
+        return periodMap[period] || 'today';
+    };
 
     /**
-     * 기간별 리더보드 데이터 계산 (메모이제이션)
+     * 리더보드 데이터 로드
      */
-    const filteredLeaderboardData = useMemo(() => {
-        const data = MOCK_LEADERBOARD_DATA[timePeriod] || MOCK_LEADERBOARD_DATA.realtime;
-        
-        // 순위 재계산
-        return data.map((user, index) => ({
-            ...user,
-            rank: index + 1
-        }));
-    }, [timePeriod]);
-
-    /**
-     * 현재 사용자 정보
-     */
-    const currentUser = useMemo(() => {
-        return MOCK_CURRENT_USER;
-    }, []);
-
-    /**
-     * 리더보드 데이터 새로고침 (실제로는 API 호출)
-     */
-    const refreshLeaderboard = async () => {
-        setLoading(true);
-        setError('');
-        
+    const loadLeaderboardData = async () => {
         try {
-            // 실제 환경에서는 API 호출
-            await new Promise(resolve => setTimeout(resolve, 1000));
-            setLoading(false);
-        } catch (error) {
+            setLoading(true);
+            setError('');
+            
+            const apiPeriod = mapTimePeriod(timePeriod);
+            
+            // 리더보드 데이터 조회
+            const leaderboardResponse = await getLeaderboard(apiPeriod, 10).catch(err => {
+                console.warn('리더보드 API 호출 실패, 목업 데이터 사용:', err);
+                return null;
+            });
+            
+            if (leaderboardResponse && leaderboardResponse.success) {
+                const transformedData = transformLeaderboardData(leaderboardResponse);
+                setLeaderboardData(transformedData);
+            } else {
+                // API 실패시 목업 데이터 사용
+                console.warn('리더보드 API 응답 실패, 목업 데이터 사용');
+                const mockPeriod = timePeriod === 'today' ? 'realtime' : timePeriod; // today -> realtime 매핑
+                const mockData = MOCK_LEADERBOARD_DATA[mockPeriod] || MOCK_LEADERBOARD_DATA.realtime;
+                setLeaderboardData(mockData.map((user, index) => ({ ...user, rank: index + 1 })));
+            }
+
+            // 현재 사용자 순위 조회 (로그인된 경우)
+            if (isAuthenticated && user && user.nickname) {
+                const userRankResponse = await getUserRank(user.nickname, apiPeriod).catch(err => {
+                    console.warn('사용자 순위 API 호출 실패, 목업 데이터 사용:', err);
+                    return null;
+                });
+                
+                if (userRankResponse && userRankResponse.success) {
+                    const transformedUserData = transformUserRankData(userRankResponse);
+                    setCurrentUser(transformedUserData);
+                } else {
+                    // API 실패시 목업 데이터 사용 (로그인된 상태에서만)
+                    console.warn('사용자 순위 API 응답 실패, 목업 데이터 사용');
+                    setCurrentUser(MOCK_CURRENT_USER);
+                }
+            } else {
+                // 로그인하지 않은 경우 currentUser를 null로 설정
+                setCurrentUser(null);
+            }
+            
+        } catch (err) {
+            console.error('리더보드 데이터 로드 중 오류:', err);
             setError('리더보드 데이터를 불러오는데 실패했습니다.');
+            
+            // 에러 발생시 목업 데이터로 fallback
+            const mockPeriod = timePeriod === 'today' ? 'realtime' : timePeriod; // today -> realtime 매핑
+            const mockData = MOCK_LEADERBOARD_DATA[mockPeriod] || MOCK_LEADERBOARD_DATA.realtime;
+            setLeaderboardData(mockData.map((user, index) => ({ ...user, rank: index + 1 })));
+            
+            // 로그인된 경우에만 목업 사용자 데이터 설정
+            if (isAuthenticated && user) {
+                setCurrentUser(MOCK_CURRENT_USER);
+            } else {
+                setCurrentUser(null);
+            }
+        } finally {
             setLoading(false);
-            console.error('리더보드 새로고침 에러:', error);
         }
     };
 
+    /**
+     * 리더보드 데이터 새로고침
+     */
+    const refreshLeaderboard = async () => {
+        await loadLeaderboardData();
+    };
+
+    // timePeriod 변경시 데이터 새로 로드
+    useEffect(() => {
+        loadLeaderboardData();
+    }, [timePeriod, isAuthenticated, user?.nickname]);
+
     return {
-        leaderboardData: filteredLeaderboardData,
+        leaderboardData,
         currentUser,
         loading,
         error,

--- a/frontend/src/features/MyActivity/api/myActivityApi.js
+++ b/frontend/src/features/MyActivity/api/myActivityApi.js
@@ -193,64 +193,76 @@ export const generateContributionTypeChart = (stats) => {
 };
 
 /**
- * 활동 추이 차트 데이터 생성 (월별 실제 기여 개수 기반)
- * @param {Object} stats - 통계 데이터
- * @param {Array} historyData - 기여 이력 데이터
+ * 활동 추이 차트 데이터 생성 (DB의 실제 contributed_at 기반 월별 집계)
+ * @param {Object} stats - 통계 데이터  
+ * @param {Array} historyData - 기여 이력 데이터 (transformHistoryData로 변환된 데이터)
  * @returns {Array} 차트 데이터
  */
 export const generateActivityTrendChart = (stats, historyData = []) => {
     const months = [];
     const currentDate = new Date();
     
-    // 월별 실제 기여 개수 집계
+    console.log('📊 활동 추이 차트 데이터 생성 시작');
+    console.log('📊 전달받은 historyData:', historyData);
+    console.log('📊 historyData 길이:', historyData.length);
+    
+    // DB에서 가져온 실제 기여 데이터를 월별로 집계
     const monthlyContributionCounts = {};
     
-    // historyData에서 실제 기여 이력을 월별로 집계
+    // historyData는 transformHistoryData로 변환된 형태:
+    // [{ date: "2024년 9월 15일", activities: [...] }, ...]
     if (historyData && historyData.length > 0) {
         historyData.forEach(dayData => {
             if (dayData.activities && dayData.activities.length > 0) {
-                dayData.activities.forEach(() => {
-                    // 활동 날짜를 파싱 (dayData.date 사용)
-                    const date = new Date(dayData.date);
-                    const monthKey = `${date.getFullYear()}-${date.getMonth()}`;
-                    
-                    if (!monthlyContributionCounts[monthKey]) {
-                        monthlyContributionCounts[monthKey] = 0;
+                // dayData.date는 "2024년 9월 15일" 형태로 formatDateForDisplay에 의해 변환됨
+                // 이를 다시 Date 객체로 파싱해야 함
+                const dateStr = dayData.date;
+                let date;
+                
+                try {
+                    // "2024년 9월 15일" 형태를 파싱
+                    const matches = dateStr.match(/(\d{4})년\s*(\d{1,2})월\s*(\d{1,2})일/);
+                    if (matches) {
+                        const [, year, month, day] = matches;
+                        date = new Date(parseInt(year), parseInt(month) - 1, parseInt(day));
+                    } else {
+                        // 파싱에 실패하면 현재 날짜 사용
+                        date = new Date();
                     }
-                    
-                    // 각 기여는 1개로 카운트 (개수 기반)
-                    monthlyContributionCounts[monthKey] += 1;
-                });
+                } catch (error) {
+                    console.warn('📊 날짜 파싱 실패:', dateStr, error);
+                    date = new Date();
+                }
+                
+                const monthKey = `${date.getFullYear()}-${date.getMonth()}`;
+                
+                if (!monthlyContributionCounts[monthKey]) {
+                    monthlyContributionCounts[monthKey] = 0;
+                }
+                
+                // 해당 날짜의 기여 개수를 월별 카운트에 추가
+                monthlyContributionCounts[monthKey] += dayData.activities.length;
+                
+                console.log(`📊 ${dateStr} (${monthKey}): ${dayData.activities.length}개 기여`);
             }
         });
     }
     
-    // 현재 월의 총 기여 개수 (stats에서 가져온 월별 데이터)
-    const currentMonthTotal = (stats?.monthlyPR || 0) + 
-                             (stats?.monthlyIssue || 0) + 
-                             (stats?.monthlyCommit || 0);
+    console.log('📊 월별 집계 결과:', monthlyContributionCounts);
     
-    // 최근 7개월 데이터 생성 (실제 데이터만 사용)
+    // 최근 7개월 데이터 생성 (실제 DB 데이터만 사용)
     for (let i = 6; i >= 0; i--) {
         const date = new Date(currentDate.getFullYear(), currentDate.getMonth() - i, 1);
         const monthName = date.toLocaleDateString('ko-KR', { month: 'short' });
         const monthKey = `${date.getFullYear()}-${date.getMonth()}`;
         
-        let value;
-        if (i === 0) {
-            // 현재 월: stats 데이터 사용 (가장 신뢰할 수 있는 데이터)
-            value = currentMonthTotal;
-        } else {
-            // 이전 월들: 실제 이력 데이터에서 집계된 값 사용, 없으면 0
-            value = monthlyContributionCounts[monthKey] || 0;
-        }
-        
+        // DB에서 집계된 실제 기여 개수 사용 (없으면 0)
+        const value = monthlyContributionCounts[monthKey] || 0;
         months.push({
             label: monthName,
             value: value
         });
     }
-    
     return months;
 };
 


### PR DESCRIPTION
## 개요
- Front mock 데이터 기반으로 동작하던 Leader Board를 실제 회원 DB와 연결하여 Controller/Service 구현
- Backend API와 연동하여 Front UI의 Leader Board 기존 mock 데이터에서 실제 데이터로 수정 

## 주요 변경 사항
- Backend LeaderBoard DTO, Service, Controller Logic 구현
- Controller API Front mock Data에 맞게 구현
- API 스펙에 맞춰 UI 구성 및 데이터 바인딩 추가
- 컴포넌트 리팩토링 및 공통 스타일 저겨용
- 불필요한 테스트/임시 파일 제거
